### PR TITLE
Fix checkbox counter

### DIFF
--- a/energy_maps/static/js/energy-maps.init.builder.v1.js
+++ b/energy_maps/static/js/energy-maps.init.builder.v1.js
@@ -383,29 +383,29 @@ let init = (function() {
     for (let i = 0; i < lay; i++) {
 
       let lyr = layers[i];
-      lyr.counter = 0;
-
+      
       initMenuItem(lyr);
 
       if (lyr.draw) {
         initMenuCheckbox(lyr);
         lyr.checkbox.on('change', function() {
-          lyr.counter++;
 
-          if (lyr.counter % 2 === 0) {
-            removeLayer(lyr);
-          } else {
+          // checkbox is buried in a ut {} object for some reason
+          let checkbox = lyr.checkbox._groups[0][0];
+
+          if (checkbox.checked) {
             addLayer(lyr, transform);
+            console.log(lyr.checkbox)
+          } else {
+            removeLayer(lyr, transform);
+            console.log(lyr.checkbox)
           }
 
-          // TODO: Arguably the legend context should be cleared in the
-          //  update_legend() function.
           legend_ctx.clearRect(0, 0, width, height);
           tmplegend_ctx.clearRect(0, 0, width, height);
           update_legend(tmplegend_ctx, legend_ctx, layers);
-  
-        });
 
+        });
       }
 
       addLayerCanvas(lyr)


### PR DESCRIPTION
Now toggles by checkbox state rather than the even/odd mod logic that was causing sync issues. 

For whatever reason though our checkboxes, when accessed via a `lyr` object, are buried in a `ut {}` object that contains an array of input objects, so you have to index through them to get the actual checkbox node in the DOM. 
![image](https://user-images.githubusercontent.com/20052075/90671308-1e15e580-e21a-11ea-849f-c433c5585e02.png)

